### PR TITLE
Fix Error -3 decompress when using JWE with deflate

### DIFF
--- a/jose/jwe.py
+++ b/jose/jwe.py
@@ -450,7 +450,7 @@ def _decompress(zip, compressed):
     if zip is None:
         decompressed = compressed
     elif zip == ZIPS.DEF:
-        decompressed = zlib.decompress(compressed)
+        decompressed = zlib.decompress(compressed,-zlib.MAX_WBITS)
     else:
         raise NotImplementedError("ZIP {} is not implemented!")
     return decompressed


### PR DESCRIPTION
Fixes header error with compression DEFLATE when decrypting payloads generated by Go,Java, and PHP JOSE implementations

`
  File "/home/me/Projects/Pycharm/TestJWE/venv/lib/python3.11/site-packages/jose/jwe.py", line 187, in decrypt
    plain_text = _decompress(header.get("zip"), plain_text)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/me/Projects/Pycharm/TestJWE/venv/lib/python3.11/site-packages/jose/jwe.py", line 453, in _decompress
    decompressed = zlib.decompress(compressed)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
zlib.error: Error -3 while decompressing data: incorrect header check
`